### PR TITLE
[Buck] Log out Thread Name when Running ShellStep

### DIFF
--- a/src/com/facebook/buck/shell/ShellStep.java
+++ b/src/com/facebook/buck/shell/ShellStep.java
@@ -42,6 +42,7 @@ import java.io.IOException;
 import java.lang.management.ManagementFactory;
 import java.lang.management.OperatingSystemMXBean;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
@@ -89,7 +90,12 @@ public abstract class ShellStep implements Step {
     // Kick off a Process in which this ShellCommand will be run.
     ProcessExecutorParams.Builder builder = ProcessExecutorParams.builder();
 
-    builder.setCommand(getShellCommand(context));
+    List<String> cmds = getShellCommand(context);
+    builder.setCommand(cmds);
+
+    String name = Thread.currentThread().getName();
+    LOG.debug("Running command: %s in Thread %s", Joiner.on(" ").join(cmds), name);
+
     Map<String, String> environment = Maps.newHashMap();
     setProcessEnvironment(context, environment, workingDirectory.toFile());
     builder.setEnvironment(environment);


### PR DESCRIPTION
First cut at helping with diagnosing issues in jenkins when the hang detection kicks in for buck.  Currently we get the thread dump, but we cannot tell what actual `ShellStep` is associated with the thread - by logging the thread name, we should be able to match a waiting thread to the last command that was executed in that thread, which should let us figure out which test is hanging.

The new output looks like this:

```
[2016-06-30 13:27:42.228][debug][command:647ae8a9-0293-4e31-bf85-d82ab567cb4c][tid:263][com.facebook.buck.shell.ShellStep] Running command: java -Djava.io.tmpdir=/Users/john.tylwalk/projects/AMP/buck-out/bin/infra/library/messaging/__java_test_test_tmp__ -Dbuck.testrunner_classes=/Users/john.tylwalk/projects/buck/build/testrunner/classes -Dcom.facebook.buck.buildId=647ae8a9-0293-4e31-bf85-d82ab567cb4c -Dcom.facebook.buck.moduleBasePath=infra/library/messaging -Drobolectric.logging=buck-out/gen/infra/library/messaging/__java_test_test_output__/logs.txt -Djava.awt.headless=true -classpath @/Users/john.tylwalk/projects/AMP/buck-out/gen/infra/library/messaging/test/classpath-file:/Users/john.tylwalk/projects/buck/build/testrunner/classes com.facebook.buck.jvm.java.runner.FileClassPathRunner com.facebook.buck.testrunner.TestNGMain --output buck-out/gen/infra/library/messaging/__java_test_test_output__ --default-test-timeout 600000 com.addepar.infra.library.messaging.DestinationTest com.addepar.infra.library.messaging.JsonSerializerTest com.addepar.infra.library.messaging.FaultTolerantQueuePublisherTest com.addepar.infra.library.messaging.WorkQueueTest com.addepar.infra.library.messaging.PubSubTest com.addepar.infra.library.messaging.HeaderTest com.addepar.infra.library.messaging.json.CustomJsonSerializerTest com.addepar.infra.library.messaging.MessagingBasedTest in Thread Test-Run-1

```

The last `in Thread Test-Run-1` helps for diagnostics.

Task: ADPR-18393

@Addepar/testing-infrastructure 
@liuyang-li 
@dant24 
