### PR TITLE
Add flag to rerun cached failures

### DIFF
--- a/src/com/facebook/buck/cli/TestCommand.java
+++ b/src/com/facebook/buck/cli/TestCommand.java
@@ -124,7 +124,7 @@ public class TestCommand extends BuildCommand {
   private boolean isBuildOnly = false;
 
   @Option(name = "--rerun-cached-failures", usage = "Rerun tests that have a cached failure.")
-  private boolean isSkipCachedFailures = false;
+  private boolean isRerunCachedFailures = false;
 
   // TODO(#9061229): See if we can remove this option entirely. For now, the
   // underlying code has been removed, and this option is ignored.
@@ -255,7 +255,7 @@ public class TestCommand extends BuildCommand {
         .setRunAllTests(isRunAllTests())
         .setTestSelectorList(testSelectorOptions.getTestSelectorList())
         .setShouldExplainTestSelectorList(testSelectorOptions.shouldExplain())
-        .setSkipCachedFailures(isSkipCachedFailures)
+        .setRerunCachedFailures(isRerunCachedFailures)
         .setResultsCacheEnabled(isResultsCacheEnabled(params.getBuckConfig()))
         .setDryRun(isDryRun)
         .setShufflingTests(isShufflingTests)

--- a/src/com/facebook/buck/cli/TestCommand.java
+++ b/src/com/facebook/buck/cli/TestCommand.java
@@ -123,6 +123,9 @@ public class TestCommand extends BuildCommand {
   @Option(name = "--build-only", usage = "Only build test targets without running tests.")
   private boolean isBuildOnly = false;
 
+  @Option(name = "--rerun-cached-failures", usage = "Rerun tests that have a cached failure.")
+  private boolean isSkipCachedFailures = false;
+
   // TODO(#9061229): See if we can remove this option entirely. For now, the
   // underlying code has been removed, and this option is ignored.
   @Option(
@@ -252,6 +255,7 @@ public class TestCommand extends BuildCommand {
         .setRunAllTests(isRunAllTests())
         .setTestSelectorList(testSelectorOptions.getTestSelectorList())
         .setShouldExplainTestSelectorList(testSelectorOptions.shouldExplain())
+        .setSkipCachedFailures(isSkipCachedFailures)
         .setResultsCacheEnabled(isResultsCacheEnabled(params.getBuckConfig()))
         .setDryRun(isDryRun)
         .setShufflingTests(isShufflingTests)

--- a/src/com/facebook/buck/cli/TestRunning.java
+++ b/src/com/facebook/buck/cli/TestRunning.java
@@ -196,7 +196,7 @@ public class TestRunning {
           options.isResultsCacheEnabled(),
           !options.getTestSelectorList().isEmpty(),
           options.isDryRun(),
-          options.isSkipCachedFailures());
+          options.isRerunCachedFailures());
 
       final Map<String, UUID> testUUIDMap = new HashMap<>();
       TestRule.TestReportingCallback testReportingCallback = new TestRule.TestReportingCallback() {
@@ -574,7 +574,7 @@ public class TestRunning {
       boolean isResultsCacheEnabled,
       boolean isRunningWithTestSelectors,
       boolean isDryRun,
-      boolean isSkipCachedFailures)
+      boolean isRerunCachedFailures)
       throws IOException, ExecutionException, InterruptedException {
     boolean isTestRunRequired;
     BuildResult result;
@@ -594,7 +594,7 @@ public class TestRunning {
             test.hasTestResultFiles(executionContext) &&
             testRuleKeyFileHelper.isRuleKeyInDir(test)) {
       try {
-        if (isSkipCachedFailures && !test.interpretTestResults(
+        if (isRerunCachedFailures && !test.interpretTestResults(
             executionContext,
             isRunningWithTestSelectors,
             isDryRun).call().isSuccess()) {

--- a/src/com/facebook/buck/test/AbstractTestRunningOptions.java
+++ b/src/com/facebook/buck/test/AbstractTestRunningOptions.java
@@ -57,7 +57,7 @@ abstract class AbstractTestRunningOptions {
   }
 
   @Value.Default
-  public boolean isSkipCachedFailures() {
+  public boolean isRerunCachedFailures() {
     return false;
   }
 

--- a/src/com/facebook/buck/test/AbstractTestRunningOptions.java
+++ b/src/com/facebook/buck/test/AbstractTestRunningOptions.java
@@ -57,6 +57,11 @@ abstract class AbstractTestRunningOptions {
   }
 
   @Value.Default
+  public boolean isSkipCachedFailures() {
+    return false;
+  }
+
+  @Value.Default
   public boolean isDryRun() {
     return false;
   }


### PR DESCRIPTION
If we decide to get rid of `--no-results-cache` on PRs, we should have this flag so that failed tests due to flakiness will still be run on subsequent runs.

@davidhao3300 for reference
