### PR TITLE
Properly output all errors in the buck test output page

### DIFF
--- a/src/com/facebook/buck/testrunner/TestNGRunner.java
+++ b/src/com/facebook/buck/testrunner/TestNGRunner.java
@@ -21,11 +21,11 @@ import com.facebook.buck.test.selectors.TestDescription;
 import org.testng.IAnnotationTransformer;
 import org.testng.IReporter;
 import org.testng.ITestContext;
-import org.testng.ITestListener;
 import org.testng.ITestResult;
 import org.testng.TestListenerAdapter;
 import org.testng.TestNG;
 import org.testng.annotations.ITestAnnotation;
+import org.testng.internal.IResultListener2;
 import org.testng.reporters.EmailableReporter;
 import org.testng.reporters.FailedReporter;
 import org.testng.reporters.JUnitReportReporter;
@@ -66,7 +66,7 @@ public final class TestNGRunner extends BaseRunner {
         results = new ArrayList<>();
         TestNG testng = new TestNG();
         testng.setUseDefaultListeners(false);
-        testng.addListener(suiteFailureListener);
+//        testng.addListener(suiteFailureListener);
         testng.setAnnotationTransformer(new TestFilter());
         testng.setTestClasses(new Class<?>[]{testClass});
         testng.addListener(new TestListener(results));
@@ -78,7 +78,19 @@ public final class TestNGRunner extends BaseRunner {
         // ... except this replaces JUnitReportReporter ...
         testng.addListener(new JUnitReportReporterImproved());
         // ... and we can't access TestNG verbosity, so we remove VerboseReporter
-        testng.run();
+        try {
+          testng.run();
+        } catch (Exception e) {
+          results.add(new TestResult(
+              className,
+              "<Initialization Error>",
+              0,
+              ResultType.FAILURE,
+              e,
+              "",
+              "")
+          );
+        }
       }
 
       writeResult(className, results);
@@ -214,47 +226,63 @@ public final class TestNGRunner extends BaseRunner {
     }
   }
 
-  private static class TestListener implements ITestListener {
+  private static class TestListener implements IResultListener2 {
     private final List<TestResult> results;
     private PrintStream originalOut, originalErr, stdOutStream, stdErrStream;
     private ByteArrayOutputStream rawStdOutBytes, rawStdErrBytes;
+    private Throwable throwable;
+
+    //buffers for holding std out/err when configuring:
+    private String stdOut;
+    private String stdErr;
 
     public TestListener(List<TestResult> results) {
       this.results = results;
     }
 
     @Override
+    public void beforeConfiguration(ITestResult result) {
+      startCapture();
+    }
+
+    @Override
+    public void onConfigurationFailure(ITestResult result) {
+      recordResult(result, ResultType.FAILURE);
+    }
+
+    @Override
+    public void onConfigurationSkip(ITestResult result) {
+      recordResult(result, ResultType.FAILURE);
+    }
+
+    @Override
+    public void onConfigurationSuccess(ITestResult result) {
+      recordResult(result, ResultType.SUCCESS);
+    }
+
+    @Override
     public void onTestStart(ITestResult result) {
-      // Create an intermediate stdout/stderr to capture any debugging statements (usually in the
-      // form of System.out.println) the developer is using to debug the test.
-      originalOut = System.out;
-      originalErr = System.err;
-      rawStdOutBytes = new ByteArrayOutputStream();
-      rawStdErrBytes = new ByteArrayOutputStream();
-      stdOutStream = streamToPrintStream(rawStdOutBytes, System.out);
-      stdErrStream = streamToPrintStream(rawStdErrBytes, System.err);
-      System.setOut(stdOutStream);
-      System.setErr(stdErrStream);
+      startCapture();
     }
 
     @Override
     public void onTestSuccess(ITestResult result) {
-      recordResult(result, ResultType.SUCCESS, result.getThrowable());
+      recordResult(result, ResultType.SUCCESS);
     }
 
     @Override
     public void onTestSkipped(ITestResult result) {
-      recordResult(result, ResultType.FAILURE, result.getThrowable());
+      recordResult(result, ResultType.FAILURE);
     }
 
     @Override
     public void onTestFailure(ITestResult result) {
-      recordResult(result, ResultType.FAILURE, result.getThrowable());
+      recordResult(result, ResultType.FAILURE);
     }
 
     @Override
     public void onTestFailedButWithinSuccessPercentage(ITestResult result) {
-      recordResult(result, ResultType.FAILURE, result.getThrowable());
+      recordResult(result, ResultType.FAILURE);
     }
 
     @Override
@@ -263,7 +291,36 @@ public final class TestNGRunner extends BaseRunner {
     @Override
     public void onFinish(ITestContext context) {}
 
-    private void recordResult(ITestResult result, ResultType type, Throwable failure) {
+    private void recordResult(ITestResult result, ResultType type) {
+      stopCapture();
+
+      String className = result.getTestClass().getName();
+      String methodName = calculateTestMethodName(result);
+
+      long runTimeMillis = result.getEndMillis() - result.getStartMillis();
+
+      results.add(new TestResult(className,
+            methodName,
+            runTimeMillis,
+            type,
+            result.getThrowable(),
+            stdOut,
+            stdErr));
+    }
+
+    private void startCapture() {
+      // Create an intermediate stdout/stderr to capture any debugging statements (usually in the
+      // form of System.out.println) the developer is using to debug the test.
+      originalOut = System.out;
+      rawStdOutBytes = new ByteArrayOutputStream();
+      rawStdErrBytes = new ByteArrayOutputStream();
+      stdOutStream = streamToPrintStream(rawStdOutBytes, System.out);
+      stdErrStream = streamToPrintStream(rawStdErrBytes, System.err);
+      System.setOut(stdOutStream);
+      System.setErr(stdErrStream);
+    }
+
+    private void stopCapture() {
       // Restore the original stdout/stderr.
       System.setOut(originalOut);
       System.setErr(originalErr);
@@ -272,27 +329,14 @@ public final class TestNGRunner extends BaseRunner {
       stdOutStream.flush();
       stdErrStream.flush();
 
-      String stdOut = streamToString(rawStdOutBytes);
-      String stdErr = streamToString(rawStdErrBytes);
-
-      String className = result.getTestClass().getName();
-      String methodName = calculateTestMethodName(result);
-
-      // use exception from suite, if available
-      if (suiteFailureListener.getThrowable() != null) {
-        failure = suiteFailureListener.getThrowable();
-        stdOut = suiteFailureListener.getStdOut();
-        stdErr = suiteFailureListener.getStdErr();
+      stdOut = streamToString(rawStdOutBytes);
+      if (stdOut == null) {
+        stdOut = "";
       }
-
-      long runTimeMillis = result.getEndMillis() - result.getStartMillis();
-      results.add(new TestResult(className,
-            methodName,
-            runTimeMillis,
-            type,
-            failure,
-            stdOut,
-            stdErr));
+      stdErr = streamToString(rawStdErrBytes);
+      if (stdErr == null) {
+        stdErr = "";
+      }
     }
 
   }

--- a/src/com/facebook/buck/testrunner/TestNGRunner.java
+++ b/src/com/facebook/buck/testrunner/TestNGRunner.java
@@ -77,7 +77,8 @@ public final class TestNGRunner extends BaseRunner {
         testng.addListener(new EmailableReporter());
         // ... except this replaces JUnitReportReporter ...
         testng.addListener(new JUnitReportReporterImproved());
-        // ... and we can't access TestNG verbosity, so we remove VerboseReporter
+        // ... and we don't want to spam the buck logs, so we remove VerboseReporter
+        // Capture any uncaught errors from TestNG
         try {
           testng.run();
         } catch (Exception e) {
@@ -230,7 +231,6 @@ public final class TestNGRunner extends BaseRunner {
     private final List<TestResult> results;
     private PrintStream originalOut, originalErr, stdOutStream, stdErrStream;
     private ByteArrayOutputStream rawStdOutBytes, rawStdErrBytes;
-    private Throwable throwable;
 
     //buffers for holding std out/err when configuring:
     private String stdOut;
@@ -312,6 +312,7 @@ public final class TestNGRunner extends BaseRunner {
       // Create an intermediate stdout/stderr to capture any debugging statements (usually in the
       // form of System.out.println) the developer is using to debug the test.
       originalOut = System.out;
+      originalErr = System.err;
       rawStdOutBytes = new ByteArrayOutputStream();
       rawStdErrBytes = new ByteArrayOutputStream();
       stdOutStream = streamToPrintStream(rawStdOutBytes, System.out);

--- a/src/com/facebook/buck/testrunner/TestNGRunner.java
+++ b/src/com/facebook/buck/testrunner/TestNGRunner.java
@@ -66,7 +66,6 @@ public final class TestNGRunner extends BaseRunner {
         results = new ArrayList<>();
         TestNG testng = new TestNG();
         testng.setUseDefaultListeners(false);
-//        testng.addListener(suiteFailureListener);
         testng.setAnnotationTransformer(new TestFilter());
         testng.setTestClasses(new Class<?>[]{testClass});
         testng.addListener(new TestListener(results));


### PR DESCRIPTION
This image should explain everything:
<img width="884" alt="screen shot 2017-06-15 at 6 19 54 pm" src="https://user-images.githubusercontent.com/5534398/27207959-6c6b0c44-51f7-11e7-94f9-651de1e0d825.png">

All before/after class/method errors are now reported properly, and even if TestNG dies due to things like Guice, we'll output the stacktrace of the testng error

@liuyang-li @jiangty-addepar 
cc @Addepar/testing-infrastructure since this'll come to Jenkins :soon:
cc @jtylwalk this'll preserve stdout/stderr that devs use to debug tests