### PR TITLE
Make results list thread-safe

### DIFF
--- a/src/com/facebook/buck/testrunner/TestNGRunner.java
+++ b/src/com/facebook/buck/testrunner/TestNGRunner.java
@@ -66,7 +66,7 @@ public final class TestNGRunner extends BaseRunner {
       if (!mightBeATestClass(testClass)) {
         results = Collections.emptyList();
       } else {
-        results = new ArrayList<>();
+        results = Collections.synchronizedList(new ArrayList<>());
         TestNG testng = new TestNG();
         testng.setUseDefaultListeners(false);
         testng.setAnnotationTransformer(new FilteringAnnotationTransformer(results));


### PR DESCRIPTION
```java.lang.ArrayIndexOutOfBoundsException: 10
at java.util.ArrayList.add(ArrayList.java:463)
at com.facebook.buck.testrunner.TestNGRunner$TestListener.recordResult(TestNGRunner.java:361)
at com.facebook.buck.testrunner.TestNGRunner$TestListener.onTestSuccess(TestNGRunner.java:329)
at org.testng.internal.TestListenerHelper.runTestListeners(TestListenerHelper.java:70)
at org.testng.internal.Invoker.runTestListeners(Invoker.java:1388)
at org.testng.internal.Invoker.invokeMethod(Invoker.java:633)
at org.testng.internal.Invoker.invokeTestMethod(Invoker.java:716)
at org.testng.internal.Invoker.invokeTestMethods(Invoker.java:988)
at org.testng.internal.TestMethodWorker.invokeTestMethods(TestMethodWorker.java:125)
at org.testng.internal.TestMethodWorker.run(TestMethodWorker.java:109)
at org.testng.internal.thread.ThreadUtil$1.call(ThreadUtil.java:52)
at java.util.concurrent.FutureTask.run(FutureTask.java:266)
at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
at java.lang.Thread.run(Thread.java:748)
```

This seems to indicate we're calling arraylist.add() in a multi-threaded way. My guess is that 2 tests from the same module finished so fast that we called recordResult() in an async, quick enough succession.

@Addepar/testing-infrastructure 