### PR TITLE
Fix "untracked file" warnings in virtualenv

### DIFF
--- a/python-dsl/buck_parser/buck.py
+++ b/python-dsl/buck_parser/buck.py
@@ -1238,10 +1238,11 @@ class BuildFileProcessor(object):
         # type: () -> bool
         """
         Returns true if the function was called from a project file.
+        Treat virtualenv files as not "inside the project".
         """
         frame = get_caller_frame(skip=[__name__])
         filename = inspect.getframeinfo(frame).filename
-        return is_in_dir(filename, self._project_root)
+        return is_in_dir(filename, self._project_root) and not self._is_path_in_virtualenv(filename)
 
     def _include_defs(self, is_implicit_include, name, namespace=None):
         # type: (bool, str, Optional[str]) -> None


### PR DESCRIPTION
Similar error as the last one (see https://github.com/facebook/buck/issues/2162#issuecomment-454959679): `linecache.py` calls `open()`, which triggers the
```
 Access to a non-tracked file detected!
```
warning when we're in a virtualenv. This causes logs to get spammed when we use virtualenvs with buck.

This change deals with that problem.

@epkugelmass @davidhao3300 