### PR TITLE
Automatically assume --java11-test-mode

### DIFF
--- a/programs/buck.py
+++ b/programs/buck.py
@@ -183,6 +183,11 @@ def _emit_java_version_warnings_if_any(java_version_status_queue):
 def main(argv, reporter):
     java_version_status_queue = Queue(maxsize=1)
 
+    # ignore the java11-test-mode flag
+    java11_test_mode_arg = "--java11-test-mode"
+    if java11_test_mode_arg in argv:
+        argv.remove(java11_test_mode_arg)
+        
     java11_test_mode = True
     required_java_version = "11"
 

--- a/programs/buck.py
+++ b/programs/buck.py
@@ -182,13 +182,9 @@ def _emit_java_version_warnings_if_any(java_version_status_queue):
 
 def main(argv, reporter):
     java_version_status_queue = Queue(maxsize=1)
-    required_java_version = "8"
 
-    java11_test_mode_arg = "--java11-test-mode"
-    java11_test_mode = java11_test_mode_arg in argv
-    if java11_test_mode:
-        argv.remove(java11_test_mode_arg)
-        required_java_version = "11"
+    java11_test_mode = True
+    required_java_version = "11"
 
     _try_to_verify_java_version_off_thread(
         java_version_status_queue, required_java_version


### PR DESCRIPTION
Annoying for all of our build tooling and users to have to specify this flag all the time.