### PR TITLE
TestNG parallel runs don't throw comodification exception

### DIFF
--- a/src/com/facebook/buck/testrunner/BaseRunner.java
+++ b/src/com/facebook/buck/testrunner/BaseRunner.java
@@ -28,6 +28,7 @@ import java.io.PrintWriter; // NOPMD can't depend on Guava
 import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -82,7 +83,7 @@ public abstract class BaseRunner {
    * The test result file is written as XML to avoid introducing a dependency on JSON (see class
    * overview).
    */
-  protected void writeResult(String testClassName, List<TestResult> results)
+  protected void writeResult(String testClassName, Collection<TestResult> results)
       throws IOException, ParserConfigurationException, TransformerException {
     // XML writer logic taken from:
     // http://www.genedavis.com/library/xml/java_dom_xml_creation.jsp


### PR DESCRIPTION
Using a concurrent linked queue to avoid `ConcurrentModificationException`. Note that [ConcurrentLinkedQueue](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/concurrent/ConcurrentLinkedQueue.html) provides a weakly consistent iterator:

> Iterators are weakly consistent, returning elements reflecting the state of the queue at some point at or since the creation of the iterator. They do not throw ConcurrentModificationException, and may proceed concurrently with other operations. Elements contained in the queue since the creation of the iterator will be returned exactly once.

I believe this guarantee is sufficient. The iterator is requested only after a test run. 

@Addepar/devprod 