### PR TITLE
Remove '--build-only' to achieve parity with facebuck

### DIFF
--- a/src/com/facebook/buck/cli/TestCommand.java
+++ b/src/com/facebook/buck/cli/TestCommand.java
@@ -148,9 +148,6 @@ public class TestCommand extends BuildCommand {
   @Nullable
   private Boolean isBuildFiltered = null;
 
-  @Option(name = "--build-only", usage = "Only build test targets without running tests.")
-  private boolean isBuildOnly = false;
-
   // TODO(#9061229): See if we can remove this option entirely. For now, the
   // underlying code has been removed, and this option is ignored.
   @Option(
@@ -658,10 +655,6 @@ public class TestCommand extends BuildCommand {
           params.getBuckEventBus().post(BuildEvent.finished(started, exitCode));
           if (exitCode != ExitCode.SUCCESS) {
             return exitCode;
-          }
-
-          if (isBuildOnly) {
-            return ExitCode.SUCCESS;
           }
 
           // If the user requests that we build tests that we filter out, then we perform


### PR DESCRIPTION
Reduces the diffs we have against facebook buck. This is no longer used. The remaining diffs _just_ might make it to facebook master if we spruce it up a little.

@Addepar/devprod 