### PR TITLE
Respect user override if abi generation mode is provided while defaullt generation mode is class

### DIFF
--- a/src/com/facebook/buck/jvm/java/DefaultJavaLibraryRules.java
+++ b/src/com/facebook/buck/jvm/java/DefaultJavaLibraryRules.java
@@ -375,8 +375,7 @@ public abstract class DefaultJavaLibraryRules {
   }
 
   private boolean shouldBuildSourceAbi() {
-    return getConfiguredCompilerFactory().shouldGenerateSourceAbi()
-        && !getSrcs().isEmpty()
+    return !getSrcs().isEmpty()
         && getPostprocessClassesCommands().isEmpty();
   }
 


### PR DESCRIPTION
If you pass in abi_generation_mode = 'source' into a java_library while abi_generation_mode = 'class' in .buckconfig, buck ignores your override value. It makes more sense to me to trust the user and let the override happen. This PR is mainly to show the diff and illustrate what the impact is.
Before:
![Screen Shot 2020-05-29 at 12 50 24 PM](https://user-images.githubusercontent.com/5534398/83284655-0135bd00-a1ab-11ea-8fab-174ce069d795.png)

After:
![Screen Shot 2020-05-29 at 12 50 01 PM](https://user-images.githubusercontent.com/5534398/83284676-098df800-a1ab-11ea-96ea-ea7f1e79042b.png)


The main changes are on the right side. The time spent solely compiling Common and Server is reduced. The biggest effect is that rest-api-server and Server libraries compile at the same time.
The pro is that the compilation time is reduced from 36s to 15s if you look at where Server just begins to compile. The con is that changes to only the private portion of the Server target will take 5 seconds longer to build.
