### PR TITLE
Standardize the output of JUnit reports

### DIFF
--- a/src/com/facebook/buck/jvm/java/JavaTest.java
+++ b/src/com/facebook/buck/jvm/java/JavaTest.java
@@ -387,8 +387,9 @@ public class JavaTest extends AbstractBuildRuleWithDeclaredAndExtraDeps
 
   @Override
   public Path getPathToTestOutputDirectory() {
-    return BuildTargetPaths.getGenPath(
-        getProjectFilesystem(), getBuildTarget(), "__java_test_%s_output__");
+    Path path = getProjectFilesystem().getPath("test-output", "junitreports");
+    path.toFile().mkdirs();
+    return path;
   }
 
   /** @return a test case result, named "main", signifying a failure of the entire test class. */

--- a/src/com/facebook/buck/jvm/java/JavaTestX.java
+++ b/src/com/facebook/buck/jvm/java/JavaTestX.java
@@ -123,8 +123,9 @@ public class JavaTestX extends AbstractBuildRuleWithDeclaredAndExtraDeps
 
   @Override
   public Path getPathToTestOutputDirectory() {
-    return BuildTargetPaths.getGenPath(
-        getProjectFilesystem(), getBuildTarget(), "__java_test_%s_output__");
+    Path path = getProjectFilesystem().getPath("test-output", "junitreports");
+    path.toFile().mkdirs();
+    return path;
   }
 
   private Path getClassPathFile() {


### PR DESCRIPTION
Between testNG and JUnit, there were different output locations. This makes it difficult for test reporters to intermingle: if a repo-wide test run contains both TestNG and JUnit tests, then test reporters will pick up only TestNG.

This is a short-term fix to get TestNG and JUnit reporting in the same position. In the end, buck is deprecated, so we won't really invest further.