### PR TITLE
[junit5] fix test runtime stats

### DIFF
--- a/src/com/facebook/buck/testrunner/JUnitRunner.java
+++ b/src/com/facebook/buck/testrunner/JUnitRunner.java
@@ -152,7 +152,8 @@ public final class JUnitRunner extends BaseRunner {
   private boolean mightBeJunit5TestClass(Class<?> klass) {
     for (Method m : klass.getMethods()) {
       if (m.getAnnotation(org.junit.jupiter.api.Test.class) != null ||
-          m.getAnnotation(org.junit.jupiter.params.ParameterizedTest.class) != null) {
+        m.getAnnotation(org.junit.jupiter.params.ParameterizedTest.class) != null ||
+        m.getAnnotation(org.junit.jupiter.api.RepeatedTest.class) != null) {
         return true;
       }
     }

--- a/src/com/facebook/buck/testrunner/Junit5TestListener.java
+++ b/src/com/facebook/buck/testrunner/Junit5TestListener.java
@@ -34,7 +34,7 @@ public class Junit5TestListener implements TestExecutionListener {
   private final Class<?> testClass;
 
   // To help give a reasonable (though imprecise) guess at the runtime for unpaired failures
-  private final long startTime = System.currentTimeMillis();
+  private long startTime = System.currentTimeMillis();
 
   public Junit5TestListener(List<TestResult> results, Level stdErrLogLevel, Level stdOutLogLevel, Class<?> testClass) {
     this.results = results;
@@ -81,6 +81,7 @@ public class Junit5TestListener implements TestExecutionListener {
     if (!testIdentifier.isTest()) {
       return;
     }
+    this.startTime = System.currentTimeMillis();
 
     // Create an intermediate stdout/stderr to capture any debugging statements (usually in the
     // form of System.out.println) the developer is using to debug the test.
@@ -179,7 +180,7 @@ public class Junit5TestListener implements TestExecutionListener {
 
     String className = testClass.getCanonicalName();
     String methodName = testIdentifier.getDisplayName().replace("()", "");
-    long runTime = summary.getTimeFinished() - summary.getTimeStarted();
+    long runTime = System.currentTimeMillis() - this.startTime;
     results.add(
       new TestResult(
         className,

--- a/src/com/facebook/buck/testrunner/Junit5TestListener.java
+++ b/src/com/facebook/buck/testrunner/Junit5TestListener.java
@@ -34,17 +34,21 @@ public class Junit5TestListener implements TestExecutionListener {
   private final Class<?> testClass;
 
   // To help give a reasonable (though imprecise) guess at the runtime for unpaired failures
-  private long startTime = System.currentTimeMillis();
+  private long testStartTime;
+  private long testPlanStartTime;
 
   public Junit5TestListener(List<TestResult> results, Level stdErrLogLevel, Level stdOutLogLevel, Class<?> testClass) {
     this.results = results;
     this.stdErrLogLevel = stdErrLogLevel;
     this.stdOutLogLevel = stdOutLogLevel;
     this.testClass = testClass;
+    this.testStartTime = System.currentTimeMillis();
+    this.testPlanStartTime = System.currentTimeMillis();
   }
 
   @Override
   public void testPlanExecutionStarted(TestPlan testPlan) {
+    this.testPlanStartTime = System.currentTimeMillis();
     listener.testPlanExecutionStarted(testPlan);
   }
 
@@ -54,7 +58,7 @@ public class Junit5TestListener implements TestExecutionListener {
     // testStarted was called for latest test, but not the testFinished
     // report all failures as unbounded
     for (TestExecutionSummary.Failure failure : listener.getSummary().getFailures()) {
-      long runtime = System.currentTimeMillis() - startTime;
+      long runtime = System.currentTimeMillis() - this.testPlanStartTime;
       String className = testClass.getCanonicalName();
       String methodName = testIdentifier.getDisplayName().replace("()", "");
       results.add(
@@ -81,8 +85,6 @@ public class Junit5TestListener implements TestExecutionListener {
     if (!testIdentifier.isTest()) {
       return;
     }
-    this.startTime = System.currentTimeMillis();
-
     // Create an intermediate stdout/stderr to capture any debugging statements (usually in the
     // form of System.out.println) the developer is using to debug the test.
     originalOut = System.out;
@@ -112,6 +114,7 @@ public class Junit5TestListener implements TestExecutionListener {
     julLogHandler = addStreamHandler(rootLogger, julLogBytes, formatter, stdOutLogLevel);
     julErrLogHandler = addStreamHandler(rootLogger, julErrLogBytes, formatter, stdErrLogLevel);
 
+    this.testStartTime = System.currentTimeMillis();
     listener.executionStarted(testIdentifier);
   }
 
@@ -180,7 +183,7 @@ public class Junit5TestListener implements TestExecutionListener {
 
     String className = testClass.getCanonicalName();
     String methodName = testIdentifier.getDisplayName().replace("()", "");
-    long runTime = System.currentTimeMillis() - this.startTime;
+    long runTime = System.currentTimeMillis() - this.testStartTime;
     results.add(
       new TestResult(
         className,


### PR DESCRIPTION
- expand test type
- reset `startTime` for each test. 

Before 
```
<testsuite failures="0" time="8.288" errors="0" skipped="0" tests="8" name="com.addepar.domain.service.accountimportmapping.AccountCreationRuleServiceImplTest">
<testcase time="0.686" classname="com.addepar.domain.service.accountimportmapping.AccountCreationRuleServiceImplTest" name="nullCheckingClassTestBaseIsNotAppliedToEnum"/>
<testcase time="0.74" classname="com.addepar.domain.service.accountimportmapping.AccountCreationRuleServiceImplTest" name="nullCheckingClassTestBaseIsNotAppliedToInstantiableClass"/>
<testcase time="0.757" classname="com.addepar.domain.service.accountimportmapping.AccountCreationRuleServiceImplTest" name="nullCheckingBestPracticeFollowedInStaticMethods"/>
<testcase time="0.762" classname="com.addepar.domain.service.accountimportmapping.AccountCreationRuleServiceImplTest" name="nullCheckingBestPracticeFollowedInConstructors"/>
<testcase time="0.789" classname="com.addepar.domain.service.accountimportmapping.AccountCreationRuleServiceImplTest" name="nullCheckingBestPracticeFollowedInInstanceMethods"/>
<testcase time="1.489" classname="com.addepar.domain.service.accountimportmapping.AccountCreationRuleServiceImplTest" name="validateInsertDefaultAccountCreationRule"/>
<testcase time="1.529" classname="com.addepar.domain.service.accountimportmapping.AccountCreationRuleServiceImplTest" name="insertRemovesDuplicates"/>
<testcase time="1.536" classname="com.addepar.domain.service.accountimportmapping.AccountCreationRuleServiceImplTest" name="testRangeValidation"/>
</testsuite>
```

After - notice the time is no longer incremental. 
```
<testsuite failures="0" time="2.979" errors="0" skipped="0" tests="8" name="com.addepar.domain.service.accountimportmapping.AccountCreationRuleServiceImplTest">
<testcase time="0.852" classname="com.addepar.domain.service.accountimportmapping.AccountCreationRuleServiceImplTest" name="nullCheckingClassTestBaseIsNotAppliedToEnum"/>
<testcase time="0.11" classname="com.addepar.domain.service.accountimportmapping.AccountCreationRuleServiceImplTest" name="nullCheckingClassTestBaseIsNotAppliedToInstantiableClass"/>
<testcase time="0.043" classname="com.addepar.domain.service.accountimportmapping.AccountCreationRuleServiceImplTest" name="nullCheckingBestPracticeFollowedInStaticMethods"/>
<testcase time="0.019" classname="com.addepar.domain.service.accountimportmapping.AccountCreationRuleServiceImplTest" name="nullCheckingBestPracticeFollowedInConstructors"/>
<testcase time="0.066" classname="com.addepar.domain.service.accountimportmapping.AccountCreationRuleServiceImplTest" name="nullCheckingBestPracticeFollowedInInstanceMethods"/>
<testcase time="1.756" classname="com.addepar.domain.service.accountimportmapping.AccountCreationRuleServiceImplTest" name="validateInsertDefaultAccountCreationRule"/>
<testcase time="0.122" classname="com.addepar.domain.service.accountimportmapping.AccountCreationRuleServiceImplTest" name="insertRemovesDuplicates"/>
<testcase time="0.011" classname="com.addepar.domain.service.accountimportmapping.AccountCreationRuleServiceImplTest" name="testRangeValidation"/>
</testsuite>
```

@scottlee14 @csaade @ztai-add  @Addepar/amp-crew 