### PR TITLE
[OX-851] JUnit5: support running individual test method

### DIFF
--- a/src/com/facebook/buck/test/selectors/PatternTestSelector.java
+++ b/src/com/facebook/buck/test/selectors/PatternTestSelector.java
@@ -141,6 +141,16 @@ public class PatternTestSelector implements TestSelector {
         isMatchAnyMethod() ? "<any>" : methodPattern);
   }
 
+  @Nullable
+  @Override
+  public String getMethod() {
+    if (methodPattern == null) {
+      return null;
+    }
+    String methodPatternString = methodPattern.toString();
+    return methodPatternString.substring(0, methodPatternString.length() - 1);
+  }
+
   @Override
   public boolean isInclusive() {
     return inclusive;

--- a/src/com/facebook/buck/test/selectors/SimpleTestSelector.java
+++ b/src/com/facebook/buck/test/selectors/SimpleTestSelector.java
@@ -46,6 +46,12 @@ public class SimpleTestSelector implements TestSelector {
         isMatchAnyClass() ? "<any>" : className, isMatchAnyMethod() ? "<any>" : methodName);
   }
 
+  @Nullable
+  @Override
+  public String getMethod() {
+    return methodName;
+  }
+
   @Override
   public boolean isInclusive() {
     return true;

--- a/src/com/facebook/buck/test/selectors/TestSelector.java
+++ b/src/com/facebook/buck/test/selectors/TestSelector.java
@@ -25,6 +25,9 @@ public interface TestSelector {
 
   String getExplanation();
 
+  @Nullable
+  String getMethod();
+
   boolean isInclusive();
 
   boolean isMatchAnyClass();

--- a/src/com/facebook/buck/test/selectors/TestSelectorList.java
+++ b/src/com/facebook/buck/test/selectors/TestSelectorList.java
@@ -111,6 +111,10 @@ public class TestSelectorList {
     return rawSelectors;
   }
 
+  public List<TestSelector> getSelectors() {
+    return testSelectors;
+  }
+
   public boolean isEmpty() {
     return testSelectors.isEmpty();
   }

--- a/src/com/facebook/buck/testrunner/JUnitRunner.java
+++ b/src/com/facebook/buck/testrunner/JUnitRunner.java
@@ -17,6 +17,7 @@
 package com.facebook.buck.testrunner;
 
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectMethod;
 
 import com.facebook.buck.test.selectors.TestDescription;
 import com.facebook.buck.test.selectors.TestSelector;
@@ -90,13 +91,24 @@ public final class JUnitRunner extends BaseRunner {
         jUnitCore.addListener(new Junit4TestListener(results, stdOutLogLevel, stdErrLogLevel, isDryRun));
         jUnitCore.run(request);
       } else if (mightBeJunit5TestClass(testClass)) {
-        LauncherDiscoveryRequest request =
-          LauncherDiscoveryRequestBuilder.request()
-            .selectors(selectClass(testClass))
-            .build();
+        LauncherDiscoveryRequestBuilder requestBuilder = LauncherDiscoveryRequestBuilder.request();
+        if (testSelectorList.isEmpty()) {
+          requestBuilder = requestBuilder.selectors(selectClass(testClass));
+        } else {
+          for (TestSelector selector : testSelectorList.getSelectors()) {
+            if (selector.matchesClassName(testClass.getSimpleName())) {
+              if (selector.isMatchAnyMethod()) {
+                requestBuilder = requestBuilder.selectors(selectClass(testClass));
+              } else {
+                requestBuilder = requestBuilder.selectors(selectMethod(testClass, selector.getMethod()));
+              }
+              break;
+            }
+          }
+        }
         Launcher launcher = LauncherFactory.create();
         Junit5TestListener listener = new Junit5TestListener(results, stdOutLogLevel, stdErrLogLevel, testClass);
-        launcher.execute(request, listener);
+        launcher.execute(requestBuilder.build(), listener);
       }
       // Combine the results with the tests we filtered out
       List<TestResult> actualResults = combineResults(results, filter.filteredOut);


### PR DESCRIPTION
The PR adds support of test selector for JUnit5 tests. 
Note: The failure count is still incorrect when there's failures, hope to address that in the future.

#### Before
```
$ ./buck test domain/service/accountreceivedate: -f AccountReceiveDateServiceTest#test2
Building: finished in 0.9 sec (100%) 2471/2471 jobs, 2 updated
  Total time: 0.9 sec
Testing: finished in 6.2 sec (2 PASS/0 FAIL)
RESULTS FOR SELECTED TESTS
PASS     113ms  2 Passed   0 Skipped   0 Failed   
                ^
com.addepar.domain.service.accountreceivedate.AccountReceiveDateServiceTest
TESTS PASSED
```

#### After
```
$ ./buck test domain/service/accountreceivedate: -f AccountReceiveDateServiceTest#test2
Building: finished in 0.8 sec (100%) 2471/2471 jobs, 0 updated
  Total time: 0.9 sec
Testing: finished in 8.9 sec (1 PASS/0 FAIL)
RESULTS FOR SELECTED TESTS
PASS     139ms  1 Passed   0 Skipped   0 Failed   
                ^
com.addepar.domain.service.accountreceivedate.AccountReceiveDateServiceTest
TESTS PASSED
```