### PR TITLE
JUnit5: fix failure count

### DIFF
--- a/src/com/facebook/buck/testrunner/JUnitRunner.java
+++ b/src/com/facebook/buck/testrunner/JUnitRunner.java
@@ -96,7 +96,8 @@ public final class JUnitRunner extends BaseRunner {
           requestBuilder = requestBuilder.selectors(selectClass(testClass));
         } else {
           for (TestSelector selector : testSelectorList.getSelectors()) {
-            if (selector.matchesClassName(testClass.getSimpleName())) {
+            if (selector.matchesClassName(testClass.getSimpleName()) ||
+              selector.matchesClassName(testClass.getCanonicalName())) {
               if (selector.isMatchAnyMethod()) {
                 requestBuilder = requestBuilder.selectors(selectClass(testClass));
               } else {

--- a/src/com/facebook/buck/testrunner/Junit5TestListener.java
+++ b/src/com/facebook/buck/testrunner/Junit5TestListener.java
@@ -52,27 +52,6 @@ public class Junit5TestListener implements TestExecutionListener {
     listener.testPlanExecutionStarted(testPlan);
   }
 
-  // compare to Junit4TestListener.testRunFinished
-  @Override
-  public void testPlanExecutionFinished(TestPlan testPlan) {
-    // testStarted was called for latest test, but not the testFinished
-    // report all failures as unbounded
-    for (TestExecutionSummary.Failure failure : listener.getSummary().getFailures()) {
-      long runtime = System.currentTimeMillis() - this.testPlanStartTime;
-      String className = testClass.getCanonicalName();
-      String methodName = testIdentifier.getDisplayName().replace("()", "");
-      results.add(
-        new TestResult(
-          className,
-          methodName,
-          runtime,
-          ResultType.FAILURE,
-          failure.getException(),
-          null,
-          null));
-    }
-  }
-
   // compare to Junit4TestListener.testIgnored
   @Override
   public void executionSkipped(TestIdentifier testIdentifier, String reason) {
@@ -150,16 +129,13 @@ public class Junit5TestListener implements TestExecutionListener {
     stdErrStream.flush();
 
     TestExecutionSummary summary = listener.getSummary();
-    long numFailures = summary.getTestsFailedCount();
-
-    TestExecutionSummary.Failure failure;
-    ResultType type;
-    if (numFailures == 0) {
-      failure = null;
-      type = ResultType.SUCCESS;
-    } else {
-      failure = summary.getFailures().get(0);
-      type = ResultType.FAILURE;
+    TestExecutionSummary.Failure failure = null;
+    ResultType type = ResultType.SUCCESS;
+    for(TestExecutionSummary.Failure f : summary.getFailures()) {
+      if(f.getTestIdentifier().equals(testIdentifier)) {
+        failure = f;
+        type = ResultType.FAILURE;
+      }
     }
 
     StringBuilder stdOut = new StringBuilder();

--- a/src/com/facebook/buck/testrunner/Junit5TestListener.java
+++ b/src/com/facebook/buck/testrunner/Junit5TestListener.java
@@ -135,6 +135,7 @@ public class Junit5TestListener implements TestExecutionListener {
       if(f.getTestIdentifier().equals(testIdentifier)) {
         failure = f;
         type = ResultType.FAILURE;
+        break;
       }
     }
 


### PR DESCRIPTION
After one test fails in a test class, all subsequent test methods will be added to the test results as failures (with identical exception) due to the hardcoded logic `summary.getFailures().get(0)` in [Junit5TestListener.java](https://github.com/Addepar/buck/blob/v2022.05.05.01/src/com/facebook/buck/testrunner/Junit5TestListener.java#L161).

The PR changes the logic to match the test to the failure with same test identifier.

#### Before
```
$ ./buck test domain/service/accountreceivedate:test -f MyTest#test1
Building: finished in 2.2 sec (100%) 174/174 jobs, 174 updated
  Total time: 5.4 sec
Testing: finished in 1.1 sec (0 PASS/2 FAIL)
RESULTS FOR SELECTED TESTS
FAIL     112ms  0 Passed   0 Skipped   2 Failed   com.addepar.domain.service.accountreceivedate.MyTest
FAILURE com.addepar.domain.service.accountreceivedate.MyTest test1:
org.opentest4j.AssertionFailedError
	at org.junit.jupiter.api.AssertionUtils.fail(AssertionUtils.java:34)
	at org.junit.jupiter.api.Assertions.fail(Assertions.java:119)
	at com.addepar.domain.service.accountreceivedate.MyTest.test1(MyTest.java:13)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1541)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1541)

FAILURE com.addepar.domain.service.accountreceivedate.MyTest test1:
org.opentest4j.AssertionFailedError
	at org.junit.jupiter.api.AssertionUtils.fail(AssertionUtils.java:34)
	at org.junit.jupiter.api.Assertions.fail(Assertions.java:119)
	at com.addepar.domain.service.accountreceivedate.MyTest.test1(MyTest.java:13)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1541)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1541)

TESTS FAILED: 2 FAILURES
Failed target: //domain/service/accountreceivedate:test
FAIL com.addepar.domain.service.accountreceivedate.MyTest
```

#### After
```
$ ./buck test domain/service/accountreceivedate:test -f MyTest#test1
Building: finished in 0.0 sec (100%) 174/174 jobs, 0 updated
  Total time: 0.0 sec
Testing: finished in 0.7 sec (0 PASS/1 FAIL)
RESULTS FOR SELECTED TESTS
FAIL    <100ms  0 Passed   0 Skipped   1 Failed   com.addepar.domain.service.accountreceivedate.MyTest
FAILURE com.addepar.domain.service.accountreceivedate.MyTest test1:
org.opentest4j.AssertionFailedError
	at org.junit.jupiter.api.AssertionUtils.fail(AssertionUtils.java:34)
	at org.junit.jupiter.api.Assertions.fail(Assertions.java:119)
	at com.addepar.domain.service.accountreceivedate.MyTest.test1(MyTest.java:13)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1541)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1541)

TESTS FAILED: 1 FAILURE
Failed target: //domain/service/accountreceivedate:test
FAIL com.addepar.domain.service.accountreceivedate.MyTest
```