### PR TITLE
BILLING-2504: Allow buck to run tests on nested test classes

### DIFF
--- a/src/com/facebook/buck/testrunner/JUnitRunner.java
+++ b/src/com/facebook/buck/testrunner/JUnitRunner.java
@@ -170,6 +170,13 @@ public final class JUnitRunner extends BaseRunner {
         return true;
       }
     }
+
+    for (Class<?> c : klass.getDeclaredClasses()) {
+      if (c.getDeclaredAnnotation(org.junit.jupiter.api.Nested.class) != null) {
+        return mightBeJunit5TestClass(c);
+      }
+    }
+
     return false;
   }
 


### PR DESCRIPTION
When running tests, buck looks for the @Test annotation on one or more methods. 

JUnit 5 provides the @Nested annotation to group tests within a class. This is useful for testing methods of a class, allowing them to have dedicated setup, teardown and custom methods. Additionally JUnit groups the tests in the output. 

When running a file with only @Tests within @Nested classes, buck will not run the test file. It will do this silently. This PR forces buck to also look into @Nested classes for methods annotated with @Test to determine whether the file is a test file or not.