### PR TITLE
Supporting junit5 dynamic tests

### DIFF
--- a/src/com/facebook/buck/testrunner/JUnitRunner.java
+++ b/src/com/facebook/buck/testrunner/JUnitRunner.java
@@ -166,6 +166,7 @@ public final class JUnitRunner extends BaseRunner {
     for (Method m : klass.getMethods()) {
       if (m.getAnnotation(org.junit.jupiter.api.Test.class) != null ||
         m.getAnnotation(org.junit.jupiter.params.ParameterizedTest.class) != null ||
+        m.getAnnotation(org.junit.jupiter.api.TestFactory.class) != null ||
         m.getAnnotation(org.junit.jupiter.api.RepeatedTest.class) != null) {
         return true;
       }


### PR DESCRIPTION
jUnit 5 introduced an API for [dynamic tests](https://junit.org/junit5/docs/current/user-guide/#writing-tests-dynamic-tests), where test instances can be generated at runtime.

Our current buck behaviour doesn't recognise the API for this, so won't run classes that just contain `@TestFactory` methods. This leaves dynamic tests as kind of a subtle footgun - they'll work fine in your IDE, or if the test class also contains a conventional test method that buck _does_ recognise, but there's a real risk of your test just being silently ignored during CI.

This PR extends buck's is-this-a-test-class check to detect methods annotated with `@TestFactory`

We tested our change on [this branch of AMP](https://github.com/Addepar/AMP/compare/ryanm/testfactory):

Before this change:
```
ryan.mcnally /Volumes/code/AMP $ ./buck test infra/library/testing:test
Action graph will be rebuilt because there was an issue with watchman:
Watchman has been initialized recently.
Building: finished in 1.1 sec (100%) 197/197 jobs, 2 updated
  Total time: 1.6 sec
Testing: finished in 0.9 sec (17 PASS/0 FAIL)
RESULTS FOR //infra/library/testing:test
PASS    <100ms  4 Passed   0 Skipped   0 Failed   com.addepar.infra.library.testing.matchers.EquivalenceMatchersTest
PASS    <100ms  6 Passed   0 Skipped   0 Failed   com.addepar.infra.library.testing.matchers.PatternMatchersTest
PASS     123ms  3 Passed   0 Skipped   0 Failed   com.addepar.infra.library.testing.matchers.SortedSetMatchersTest
PASS    <100ms  4 Passed   0 Skipped   0 Failed   com.addepar.infra.library.testing.util.ExpectationBatchTest
TESTS PASSED
```

After this change:
```
ryan.mcnally /Volumes/code/AMP $ ./buck test infra/library/testing:test
Addepar Buck ==> Buck hash mismsatch! Desired buck version: v11.
Addepar Buck ==>  !!! File '.ignore-buck-version' is present! Buck update to v11 has stopped!
Addepar Buck ==>  !!! Remove '.ignore-buck-version' to allow buck to update. Your code may not work without updating buck!
Building: finished in 0.6 sec (100%) 197/197 jobs, 2 updated
  Total time: 0.7 sec
Testing: finished in 0.9 sec (23 PASS/0 FAIL)
RESULTS FOR //infra/library/testing:test
PASS    <100ms  4 Passed   0 Skipped   0 Failed   com.addepar.infra.library.testing.matchers.EquivalenceMatchersTest
PASS    <100ms  6 Passed   0 Skipped   0 Failed   com.addepar.infra.library.testing.matchers.PatternMatchersTest
PASS    <100ms  3 Passed   0 Skipped   0 Failed   com.addepar.infra.library.testing.matchers.SortedSetMatchersTest
PASS    <100ms  4 Passed   0 Skipped   0 Failed   com.addepar.infra.library.testing.util.ExpectationBatchTest
PASS    <100ms  6 Passed   0 Skipped   0 Failed   com.addepar.infra.library.testing.util.TestFactoryExampleTest
TESTS PASSED

```

This is an enabler for Addepar/AMP#80022